### PR TITLE
modify for removing data race

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -22,10 +22,11 @@ import (
 
 	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
 
+	"strconv"
+
 	"boscoin.io/sebak/lib"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/node/runner"
-	"strconv"
 )
 
 const defaultNetwork string = "https"
@@ -337,7 +338,7 @@ func runNode() error {
 		return err
 	}
 
-	isaac, err := consensus.NewISAAC([]byte(flagNetworkID), localNode, policy)
+	isaac, err := consensus.NewISAAC([]byte(flagNetworkID), localNode, policy, nt)
 	if err != nil {
 		log.Crit("failed to launch consensus", "error", err)
 		return err

--- a/lib/consensus/isaac.go
+++ b/lib/consensus/isaac.go
@@ -38,6 +38,8 @@ func (is *ISAAC) CloseConsensus(proposer string, round round.Round, vh common.Vo
 	is.Lock()
 	defer is.Unlock()
 
+	is.SetLatestRound(round)
+
 	if vh == common.VotingNOTYET {
 		err = errors.New("invalid VotingHole, `VotingNOTYET`")
 		return

--- a/lib/consensus/isaac_configuration.go
+++ b/lib/consensus/isaac_configuration.go
@@ -1,8 +1,6 @@
-//
 // ISAACConfiguration has timeout features and transaction limit.
 // The ISAACConfiguration is included in ISAACStateManager and
 // these timeout features are used in ISAAC consensus.
-//
 package consensus
 
 import (

--- a/lib/consensus/isaac_state.go
+++ b/lib/consensus/isaac_state.go
@@ -1,0 +1,24 @@
+// When a node receives a ballot,
+// if the ISAACState of the ballot is before than the ISAACState of node,
+// the ballot is ignored.
+
+package consensus
+
+import (
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/consensus/round"
+)
+
+type ISAACState struct {
+	Round       round.Round
+	BallotState common.BallotState
+}
+
+func NewISAACState(round round.Round, ballotState common.BallotState) ISAACState {
+	p := ISAACState{
+		Round:       round,
+		BallotState: ballotState,
+	}
+
+	return p
+}

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -89,7 +89,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, mn *network.HTTP2Net
 	mn = network.NewHTTP2Network(config)
 
 	p, _ := consensus.NewDefaultVotingThresholdPolicy(30, 30)
-	is, _ := consensus.NewISAAC(networkID, localNode, p)
+	is, _ := consensus.NewISAAC(networkID, localNode, p, mn)
 	st, _ := storage.NewTestMemoryLevelDBBackend()
 	// Make the latest block
 	{

--- a/lib/node/runner/broadcaster_test.go
+++ b/lib/node/runner/broadcaster_test.go
@@ -16,8 +16,10 @@ func TestConnectionManagerBroadcaster(t *testing.T) {
 	recv := make(chan struct{})
 
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(SelfProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 

--- a/lib/node/runner/broadcaster_test.go
+++ b/lib/node/runner/broadcaster_test.go
@@ -1,0 +1,33 @@
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"boscoin.io/sebak/lib/consensus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionManagerBroadcaster(t *testing.T) {
+	nodeRunners := createTestNodeRunner(3)
+
+	nr := nodeRunners[0]
+
+	recv := make(chan struct{})
+
+	b := NewTestBroadcaster(recv)
+	nr.SetBroadcaster(b)
+	nr.SetProposerCalculator(SelfProposerCalculator{})
+
+	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	conf := consensus.NewISAACConfiguration()
+	conf.TimeoutALLCONFIRM = 1 * time.Millisecond
+
+	nr.SetConf(conf)
+
+	nr.StartStateManager()
+
+	<-recv
+	require.Equal(t, 1, len(b.Messages()))
+}

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -39,7 +39,6 @@ type BallotChecker struct {
 	IsNew              bool
 	Ballot             block.Ballot
 	VotingHole         common.VotingHole
-	RoundVote          *consensus.RoundVote
 	Result             consensus.RoundVoteResult
 	VotingFinished     bool
 	FinishedVotingHole common.VotingHole
@@ -106,17 +105,8 @@ func BallotAlreadyFinished(c common.Checker, args ...interface{}) (err error) {
 // BallotAlreadyVoted checks the node of ballot voted.
 func BallotAlreadyVoted(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
-	rr := checker.NodeRunner.Consensus().RunningRounds
-
-	var found bool
-	var runningRound *consensus.RunningRound
-	if runningRound, found = rr[checker.Ballot.Round().Hash()]; !found {
-		return
-	}
-
-	if runningRound.IsVoted(checker.Ballot) {
+	if checker.NodeRunner.Consensus().IsVoted(checker.Ballot) {
 		err = errors.ErrorBallotAlreadyVoted
-		return
 	}
 
 	return
@@ -128,40 +118,8 @@ func BallotAlreadyVoted(c common.Checker, args ...interface{}) (err error) {
 func BallotVote(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
-	roundHash := checker.Ballot.Round().Hash()
-	rr := checker.NodeRunner.Consensus().RunningRounds
-
-	var isNew bool
-	var found bool
-	var runningRound *consensus.RunningRound
-	if runningRound, found = rr[roundHash]; !found {
-		proposer := checker.NodeRunner.CalculateProposer(
-			checker.Ballot.Round().BlockHeight,
-			checker.Ballot.Round().Number,
-		)
-
-		runningRound, err = consensus.NewRunningRound(proposer, checker.Ballot)
-		if err != nil {
-			return
-		}
-
-		rr[roundHash] = runningRound
-		isNew = true
-	} else {
-		if _, found = runningRound.Voted[checker.Ballot.Proposer()]; !found {
-			isNew = true
-		}
-
-		runningRound.Vote(checker.Ballot)
-	}
-
-	checker.IsNew = isNew
-	checker.RoundVote, err = runningRound.RoundVote(checker.Ballot.Proposer())
-	if err != nil {
-		return
-	}
-
-	checker.Log.Debug("ballot voted", "runningRound", runningRound, "new", isNew)
+	checker.IsNew, err = checker.NodeRunner.Consensus().Vote(checker.Ballot)
+	checker.Log.Debug("ballot voted", "ballot", checker.Ballot, "new", checker.IsNew)
 
 	return
 }
@@ -179,17 +137,14 @@ func BallotIsSameProposer(c common.Checker, args ...interface{}) (err error) {
 		return
 	}
 
-	rr := checker.NodeRunner.Consensus().RunningRounds
-	var runningRound *consensus.RunningRound
-	var found bool
-	if runningRound, found = rr[checker.Ballot.Round().Hash()]; !found {
+	if !checker.NodeRunner.Consensus().HasRunningRound(checker.Ballot.Round().Hash()) {
 		err = errors.New("`RunningRound` not found")
 		return
 	}
 
-	if runningRound.Proposer != checker.Ballot.Proposer() {
+	if !checker.NodeRunner.Consensus().HasSameProposer(checker.Ballot) {
 		checker.VotingHole = common.VotingNO
-		checker.Log.Debug("ballot has different proposer", "proposer", runningRound.Proposer)
+		checker.Log.Debug("ballot has different proposer", "proposer", checker.Ballot.Proposer())
 		return
 	}
 
@@ -204,10 +159,7 @@ func BallotCheckResult(c common.Checker, args ...interface{}) (err error) {
 		return
 	}
 
-	result, votingHole, finished := checker.RoundVote.CanGetVotingResult(
-		checker.NodeRunner.Consensus().VotingThresholdPolicy,
-		checker.Ballot.State(),
-	)
+	result, votingHole, finished := checker.NodeRunner.Consensus().CanGetVotingResult(checker.Ballot)
 
 	checker.Result = result
 	checker.VotingFinished = finished
@@ -239,8 +191,9 @@ func INITBallotValidateTransactions(c common.Checker, args ...interface{}) (err 
 	if !checker.IsNew || checker.VotingFinished {
 		return
 	}
-
-	if checker.RoundVote.IsVotedByNode(checker.Ballot.State(), checker.LocalNode.Address()) {
+	var voted bool
+	voted, err = checker.NodeRunner.Consensus().IsVotedByNode(checker.Ballot, checker.LocalNode.Address())
+	if voted || err != nil {
 		err = errors.ErrorBallotAlreadyVoted
 		return
 	}
@@ -295,15 +248,12 @@ func SIGNBallotBroadcast(c common.Checker, args ...interface{}) (err error) {
 	newBallot.SetVote(common.BallotStateSIGN, checker.VotingHole)
 	newBallot.Sign(checker.LocalNode.Keypair(), checker.NetworkID)
 
-	rr := checker.NodeRunner.Consensus().RunningRounds
-
-	var runningRound *consensus.RunningRound
-	var found bool
-	if runningRound, found = rr[checker.Ballot.Round().Hash()]; !found {
+	if !checker.NodeRunner.Consensus().HasRunningRound(checker.Ballot.Round().Hash()) {
 		err = errors.New("RunningRound not found")
 		return
+
 	}
-	runningRound.Vote(newBallot)
+	checker.NodeRunner.Consensus().Vote(newBallot)
 
 	checker.NodeRunner.ConnectionManager().Broadcast(newBallot)
 	checker.Log.Debug("ballot will be broadcasted", "newBallot", newBallot)
@@ -334,15 +284,12 @@ func ACCEPTBallotBroadcast(c common.Checker, args ...interface{}) (err error) {
 	newBallot.SetVote(common.BallotStateACCEPT, checker.FinishedVotingHole)
 	newBallot.Sign(checker.LocalNode.Keypair(), checker.NetworkID)
 
-	rr := checker.NodeRunner.Consensus().RunningRounds
-	var runningRound *consensus.RunningRound
-	var found bool
-	if runningRound, found = rr[checker.Ballot.Round().Hash()]; !found {
+	if !checker.NodeRunner.Consensus().HasRunningRound(checker.Ballot.Round().Hash()) {
 		err = errors.New("RunningRound not found")
 		return
-	}
-	runningRound.Vote(newBallot)
 
+	}
+	checker.NodeRunner.Consensus().Vote(newBallot)
 	checker.NodeRunner.ConnectionManager().Broadcast(newBallot)
 	checker.Log.Debug("ballot will be broadcasted", "newBallot", newBallot)
 

--- a/lib/node/runner/checker_message_test.go
+++ b/lib/node/runner/checker_message_test.go
@@ -21,7 +21,7 @@ func TestMessageChecker(t *testing.T) {
 	}
 
 	validMessage := common.NetworkMessage{Type: common.TransactionMessage, Data: b}
-	nodeRunner, localNode := MakeNodeRunner(nil)
+	nodeRunner, localNode := MakeNodeRunner()
 	checker := &MessageChecker{
 		DefaultChecker: common.DefaultChecker{},
 		NodeRunner:     nodeRunner,
@@ -83,7 +83,7 @@ func TestMessageCheckerWithInvalidMessage(t *testing.T) {
 	}
 
 	invalidMessage := common.NetworkMessage{Type: common.TransactionMessage, Data: b}
-	nodeRunner, localNode := MakeNodeRunner(nil)
+	nodeRunner, localNode := MakeNodeRunner()
 	checker := &MessageChecker{
 		NodeRunner: nodeRunner,
 		LocalNode:  localNode,

--- a/lib/node/runner/isaac_simulation_test.go
+++ b/lib/node/runner/isaac_simulation_test.go
@@ -31,7 +31,9 @@ func TestISAACSimulationProposer(t *testing.T) {
 	nodeRunner := nodeRunners[0]
 
 	// `nodeRunner` is proposer's runner
-	nodeRunner.SetProposerCalculator(SelfProposerCalculator{})
+	nodeRunner.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nodeRunner,
+	})
 	proposer := nodeRunner.localNode
 
 	nodeRunner.Consensus().SetLatestConsensusedBlock(genesisBlock)
@@ -46,11 +48,13 @@ func TestISAACSimulationProposer(t *testing.T) {
 	roundNumber := uint64(0)
 	err = nodeRunner.proposeNewBallot(roundNumber)
 	require.Nil(t, err)
+
+	b := nodeRunner.Consensus().LatestConfirmedBlock()
 	round := round.Round{
 		Number:      roundNumber,
-		BlockHeight: nodeRunner.Consensus().LatestConfirmedBlock.Height,
-		BlockHash:   nodeRunner.Consensus().LatestConfirmedBlock.Hash,
-		TotalTxs:    nodeRunner.Consensus().LatestConfirmedBlock.TotalTxs,
+		BlockHeight: b.Height,
+		BlockHash:   b.Hash,
+		TotalTxs:    b.TotalTxs,
 	}
 	runningRounds := nodeRunner.Consensus().RunningRounds
 
@@ -97,7 +101,7 @@ func TestISAACSimulationProposer(t *testing.T) {
 
 	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(common.BallotStateACCEPT)))
 
-	block := nodeRunner.Consensus().LatestConfirmedBlock
+	block := nodeRunner.Consensus().LatestConfirmedBlock()
 	require.Equal(t, proposer.Address(), block.Proposer)
 	require.Equal(t, 1, len(block.Transactions))
 	require.Equal(t, tx.GetHash(), block.Transactions[0])

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -1,0 +1,224 @@
+package runner
+
+import (
+	"sync"
+	"time"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/consensus"
+	"boscoin.io/sebak/lib/consensus/round"
+)
+
+// ISAACStateManager manages the ISAACState.
+// The most important function `Start()` is called in StartStateManager() function in node_runner.go by goroutine.
+type ISAACStateManager struct {
+	sync.RWMutex
+
+	nr            *NodeRunner
+	state         consensus.ISAACState
+	Conf          *consensus.ISAACConfiguration
+	stateTransit  chan consensus.ISAACState
+	stop          chan struct{}
+	transitSignal func() // `transitSignal` is function which is called when the ISAACState is changed.
+}
+
+func NewISAACStateManager(nr *NodeRunner) *ISAACStateManager {
+	p := &ISAACStateManager{
+		Conf: consensus.NewISAACConfiguration(),
+		nr:   nr,
+	}
+	p.stateTransit = make(chan consensus.ISAACState)
+	p.stop = make(chan struct{})
+
+	p.state = consensus.NewISAACState(
+		round.Round{
+			Number:      0,
+			BlockHeight: 0,
+		},
+		common.BallotStateINIT,
+	)
+
+	p.transitSignal = func() {}
+
+	return p
+}
+
+func (sm *ISAACStateManager) SetConf(conf *consensus.ISAACConfiguration) {
+	sm.Conf = conf
+}
+
+func (sm *ISAACStateManager) SetTransitSignal(f func()) {
+	sm.transitSignal = f
+}
+
+func (sm *ISAACStateManager) TransitISAACState(round round.Round, ballotState common.BallotState) {
+	sm.RLock()
+	current := sm.state
+	sm.RUnlock()
+
+	target := consensus.NewISAACState(round, ballotState)
+
+	if isTargetLater(current, target) {
+		go func() {
+			sm.stateTransit <- target
+		}()
+	}
+}
+
+func isTargetLater(state consensus.ISAACState, target consensus.ISAACState) (result bool) {
+	if state.Round.BlockHeight > target.Round.BlockHeight {
+		result = false
+	} else if state.Round.BlockHeight < target.Round.BlockHeight {
+		result = true
+	} else { // state.Round.BlockHeight == target.Round.BlockHeight
+		if state.Round.Number > target.Round.Number {
+			result = false
+		} else if state.Round.Number < target.Round.Number {
+			result = true
+		} else { // state.Round.Number == target.Round.Number
+			if state.BallotState >= target.BallotState {
+				result = false
+			} else {
+				result = true
+			}
+		}
+	}
+	return result
+}
+
+func (sm *ISAACStateManager) IncreaseRound() {
+	round := sm.State().Round
+	round.Number++
+	sm.TransitISAACState(round, common.BallotStateINIT)
+}
+
+func (sm *ISAACStateManager) NextHeight() {
+	round := sm.State().Round
+	round.BlockHeight++
+	round.Number = 0
+	sm.TransitISAACState(round, common.BallotStateINIT)
+}
+
+// In `Start()` method a node proposes ballot.
+// Or it sets or resets timeout. If it is expired, it broadcasts B(`EXP`).
+// And it manages the node round.
+func (sm *ISAACStateManager) Start() {
+	go func() {
+		timer := time.NewTimer(time.Duration(1 * time.Hour))
+		for {
+			select {
+			case <-timer.C:
+				if sm.State().BallotState == common.BallotStateACCEPT {
+					sm.IncreaseRound()
+					break
+				}
+				go sm.broadcastExpiredBallot(sm.State())
+				sm.setBallotState(sm.State().BallotState.Next())
+				sm.resetTimer(timer, sm.State().BallotState)
+				sm.transitSignal()
+
+			case state := <-sm.stateTransit:
+				switch state.BallotState {
+				case common.BallotStateINIT:
+					sm.proposeOrWait(timer, state)
+				case common.BallotStateSIGN:
+					sm.setState(state)
+					sm.transitSignal()
+					timer.Reset(sm.Conf.TimeoutSIGN)
+				case common.BallotStateACCEPT:
+					sm.setState(state)
+					sm.transitSignal()
+					timer.Reset(sm.Conf.TimeoutACCEPT)
+				case common.BallotStateALLCONFIRM:
+					sm.NextHeight()
+				case common.BallotStateNONE:
+					timer.Reset(sm.Conf.TimeoutINIT)
+					log.Error("Wrong ISAACState", "ISAACState", state)
+				}
+
+			case <-sm.stop:
+				return
+			}
+		}
+	}()
+}
+
+func (sm *ISAACStateManager) broadcastExpiredBallot(state consensus.ISAACState) {
+	round := round.Round{
+		Number:      state.Round.Number,
+		BlockHeight: sm.nr.consensus.LatestConfirmedBlock.Height,
+		BlockHash:   sm.nr.consensus.LatestConfirmedBlock.Hash,
+		TotalTxs:    sm.nr.consensus.LatestConfirmedBlock.TotalTxs,
+	}
+
+	newExpiredBallot := block.NewBallot(sm.nr.localNode, round, []string{})
+	newExpiredBallot.SetVote(state.BallotState.Next(), common.VotingEXP)
+	newExpiredBallot.Sign(sm.nr.localNode.Keypair(), sm.nr.networkID)
+
+	sm.nr.ConnectionManager().Broadcast(*newExpiredBallot)
+}
+
+func (sm *ISAACStateManager) resetTimer(timer *time.Timer, state common.BallotState) {
+	switch state {
+	case common.BallotStateINIT:
+		timer.Reset(sm.Conf.TimeoutINIT)
+	case common.BallotStateSIGN:
+		timer.Reset(sm.Conf.TimeoutSIGN)
+	case common.BallotStateACCEPT:
+		timer.Reset(sm.Conf.TimeoutACCEPT)
+	}
+}
+
+func (sm *ISAACStateManager) proposeOrWait(timer *time.Timer, state consensus.ISAACState) {
+	timer.Reset(time.Duration(1 * time.Hour))
+	proposer := sm.nr.CalculateProposer(state.Round.BlockHeight, state.Round.Number)
+	log.Debug("calculated proposer", "proposer", proposer)
+
+	if proposer == sm.nr.localNode.Address() {
+		if err := sm.nr.proposeNewBallot(state.Round.Number); err == nil {
+			log.Debug("propose new ballot", "proposer", proposer, "round", state.Round, "ballotState", common.BallotStateSIGN)
+			state.BallotState = common.BallotStateSIGN
+			sm.setState(state)
+
+			timer.Reset(sm.Conf.TimeoutSIGN)
+			sm.transitSignal()
+		} else {
+			log.Error("failed to proposeNewBallot", "height", sm.nr.consensus.LatestConfirmedBlock.Height, "error", err)
+			sm.setState(state)
+			timer.Reset(sm.Conf.TimeoutINIT)
+		}
+	} else {
+		sm.setState(state)
+		timer.Reset(sm.Conf.TimeoutINIT)
+		sm.transitSignal()
+	}
+}
+
+func (sm *ISAACStateManager) State() consensus.ISAACState {
+	sm.RLock()
+	defer sm.RUnlock()
+	return sm.state
+}
+
+func (sm *ISAACStateManager) setState(state consensus.ISAACState) {
+	sm.Lock()
+	defer sm.Unlock()
+	sm.state = state
+
+	return
+}
+
+func (sm *ISAACStateManager) setBallotState(ballotState common.BallotState) {
+	sm.Lock()
+	defer sm.Unlock()
+	sm.state.BallotState = ballotState
+
+	return
+}
+
+func (sm *ISAACStateManager) Stop() {
+	go func() {
+		sm.stop <- struct{}{}
+	}()
+}

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -145,11 +145,12 @@ func (sm *ISAACStateManager) Start() {
 }
 
 func (sm *ISAACStateManager) broadcastExpiredBallot(state consensus.ISAACState) {
+	b := sm.nr.consensus.LatestConfirmedBlock()
 	round := round.Round{
 		Number:      state.Round.Number,
-		BlockHeight: sm.nr.consensus.LatestConfirmedBlock.Height,
-		BlockHash:   sm.nr.consensus.LatestConfirmedBlock.Hash,
-		TotalTxs:    sm.nr.consensus.LatestConfirmedBlock.TotalTxs,
+		BlockHeight: b.Height,
+		BlockHash:   b.Hash,
+		TotalTxs:    b.TotalTxs,
 	}
 
 	newExpiredBallot := block.NewBallot(sm.nr.localNode, round, []string{})
@@ -172,7 +173,7 @@ func (sm *ISAACStateManager) resetTimer(timer *time.Timer, state common.BallotSt
 
 func (sm *ISAACStateManager) proposeOrWait(timer *time.Timer, state consensus.ISAACState) {
 	timer.Reset(time.Duration(1 * time.Hour))
-	proposer := sm.nr.CalculateProposer(state.Round.BlockHeight, state.Round.Number)
+	proposer := sm.nr.Consensus().CalculateProposer(state.Round.BlockHeight, state.Round.Number)
 	log.Debug("calculated proposer", "proposer", proposer)
 
 	if proposer == sm.nr.localNode.Address() {
@@ -184,7 +185,7 @@ func (sm *ISAACStateManager) proposeOrWait(timer *time.Timer, state consensus.IS
 			timer.Reset(sm.Conf.TimeoutSIGN)
 			sm.transitSignal()
 		} else {
-			log.Error("failed to proposeNewBallot", "height", sm.nr.consensus.LatestConfirmedBlock.Height, "error", err)
+			log.Error("failed to proposeNewBallot", "height", sm.nr.consensus.LatestConfirmedBlock().Height, "error", err)
 			sm.setState(state)
 			timer.Reset(sm.Conf.TimeoutINIT)
 		}

--- a/lib/node/runner/isaac_state_transit_test.go
+++ b/lib/node/runner/isaac_state_transit_test.go
@@ -22,8 +22,10 @@ func TestStateINITProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(SelfProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 
@@ -57,8 +59,10 @@ func TestStateINITNotProposer(t *testing.T) {
 	nr := nodeRunners[0]
 
 	b := NewTestBroadcaster(nil)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(TheOtherProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(TheOtherProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 
@@ -88,9 +92,11 @@ func TestStateINITTimeoutNotProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(TheOtherProposerCalculator{})
-	proposer := nr.CalculateProposer(0, 0)
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(TheOtherProposerCalculator{
+		nodeRunner: nr,
+	})
+	proposer := nr.Consensus().CalculateProposer(0, 0)
 
 	require.NotEqual(t, nr.localNode.Address(), proposer)
 
@@ -144,9 +150,11 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(SelfProposerCalculator{})
-	proposer := nr.CalculateProposer(0, 0)
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nr,
+	})
+	proposer := nr.Consensus().CalculateProposer(0, 0)
 
 	require.Equal(t, nr.localNode.Address(), proposer)
 
@@ -208,9 +216,11 @@ func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(TheOtherProposerCalculator{})
-	proposer := nr.CalculateProposer(0, 0)
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(TheOtherProposerCalculator{
+		nodeRunner: nr,
+	})
+	proposer := nr.Consensus().CalculateProposer(0, 0)
 
 	require.NotEqual(t, nr.localNode.Address(), proposer)
 
@@ -267,13 +277,15 @@ func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(&SelfProposerThenNotProposer{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(&SelfProposerThenNotProposer{
+		nodeRunner: nr,
+	})
 
-	proposer := nr.CalculateProposer(0, 0)
+	proposer := nr.Consensus().CalculateProposer(0, 0)
 	require.Equal(t, nr.localNode.Address(), proposer)
 
-	proposer = nr.CalculateProposer(0, 1)
+	proposer = nr.Consensus().CalculateProposer(0, 1)
 	require.NotEqual(t, nr.localNode.Address(), proposer)
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
@@ -333,8 +345,10 @@ func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
 
 	recvBroadcast := make(chan struct{})
 	b := NewTestBroadcaster(recvBroadcast)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(TheOtherProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(TheOtherProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 
@@ -380,8 +394,10 @@ func TestStateTransitFromTimeoutSignToAccept(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(SelfProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 

--- a/lib/node/runner/isaac_state_transit_test.go
+++ b/lib/node/runner/isaac_state_transit_test.go
@@ -1,0 +1,419 @@
+// We can test that a node broadcast propose ballot or B(`EXP`) in ISAACStateManager.
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/consensus"
+)
+
+// 1. All 3 Nodes.
+// 2. Proposer itself.
+// 3. When `ISAACStateManager` starts, the node proposes ballot to validators.
+func TestStateINITProposer(t *testing.T) {
+	nodeRunners := createTestNodeRunner(3)
+
+	nr := nodeRunners[0]
+
+	recv := make(chan struct{})
+	b := NewTestBroadcaster(recv)
+	nr.SetBroadcaster(b)
+	nr.SetProposerCalculator(SelfProposerCalculator{})
+
+	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	conf := consensus.NewISAACConfiguration()
+	conf.TimeoutINIT = time.Hour
+	conf.TimeoutSIGN = time.Hour
+	conf.TimeoutACCEPT = time.Hour
+	conf.TimeoutALLCONFIRM = time.Hour
+
+	nr.SetConf(conf)
+
+	nr.StartStateManager()
+
+	<-recv
+	require.Equal(t, 1, len(b.Messages()))
+	for _, message := range b.Messages() {
+		// This message must be proposed ballot
+		b, ok := message.(block.Ballot)
+		require.True(t, ok)
+		require.Equal(t, nr.localNode.Address(), b.Proposer())
+	}
+}
+
+// 1. All 3 Nodes.
+// 2. Not proposer itself.
+// 3. When `ISAACStateManager` starts, the node waits a ballot by proposer.
+// 4. But TimeoutINIT is an hour, so it doesn't broadcast anything.
+func TestStateINITNotProposer(t *testing.T) {
+	nodeRunners := createTestNodeRunner(3)
+
+	nr := nodeRunners[0]
+
+	b := NewTestBroadcaster(nil)
+	nr.SetBroadcaster(b)
+	nr.SetProposerCalculator(TheOtherProposerCalculator{})
+
+	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	conf := consensus.NewISAACConfiguration()
+	conf.TimeoutINIT = time.Hour
+	conf.TimeoutSIGN = time.Hour
+	conf.TimeoutACCEPT = time.Hour
+	conf.TimeoutALLCONFIRM = time.Hour
+
+	nr.SetConf(conf)
+
+	nr.StartStateManager()
+	time.Sleep(1 * time.Second)
+
+	require.Equal(t, 0, len(b.Messages()))
+}
+
+// 1. All 3 Nodes.
+// 2. Not proposer itself.
+// 3. When `ISAACStateManager` starts, the node waits a ballot by proposer.
+// 4. But TimeoutINIT is a millisecond.
+// 5. After timeout, the node broadcasts B(`SIGN`, `EXP`)
+func TestStateINITTimeoutNotProposer(t *testing.T) {
+	nodeRunners := createTestNodeRunner(3)
+
+	nr := nodeRunners[0]
+
+	recv := make(chan struct{})
+	b := NewTestBroadcaster(recv)
+	nr.SetBroadcaster(b)
+	nr.SetProposerCalculator(TheOtherProposerCalculator{})
+	proposer := nr.CalculateProposer(0, 0)
+
+	require.NotEqual(t, nr.localNode.Address(), proposer)
+
+	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	conf := consensus.NewISAACConfiguration()
+	conf.TimeoutINIT = 1 * time.Millisecond
+	conf.TimeoutSIGN = time.Hour
+	conf.TimeoutACCEPT = time.Hour
+	conf.TimeoutALLCONFIRM = time.Hour
+
+	nr.SetConf(conf)
+
+	nr.StartStateManager()
+	require.Equal(t, common.BallotStateINIT, nr.isaacStateManager.State().BallotState)
+
+	<-recv
+	require.Equal(t, common.BallotStateSIGN, nr.isaacStateManager.State().BallotState)
+
+	require.Equal(t, 1, len(b.Messages()))
+	init, sign, accept := 0, 0, 0
+	for _, message := range b.Messages() {
+		b, ok := message.(block.Ballot)
+		require.True(t, ok)
+		require.Equal(t, 0, len(b.Transactions()))
+		switch b.State() {
+		case common.BallotStateINIT:
+			init++
+		case common.BallotStateSIGN:
+			sign++
+			require.Equal(t, common.VotingEXP, b.Vote())
+		case common.BallotStateACCEPT:
+			accept++
+		}
+	}
+	require.Equal(t, 0, init)
+	require.Equal(t, 1, sign)
+	require.Equal(t, 0, accept)
+}
+
+// 1. All 3 Nodes.
+// 2. Proposer itself.
+// 3. When `ISAACStateManager` starts, the node proposes B(`INIT`, `YES`) to validators.
+// 4. Then ISAACState will be changed to `SIGN`.
+// 5. But TimeoutSIGN is a millisecond.
+// 6. After timeout, the node broadcasts B(`ACCEPT`, `EXP`)
+func TestStateSIGNTimeoutProposer(t *testing.T) {
+	nodeRunners := createTestNodeRunner(3)
+
+	nr := nodeRunners[0]
+
+	recv := make(chan struct{})
+	b := NewTestBroadcaster(recv)
+	nr.SetBroadcaster(b)
+	nr.SetProposerCalculator(SelfProposerCalculator{})
+	proposer := nr.CalculateProposer(0, 0)
+
+	require.Equal(t, nr.localNode.Address(), proposer)
+
+	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	conf := consensus.NewISAACConfiguration()
+	conf.TimeoutINIT = time.Hour
+	conf.TimeoutSIGN = time.Millisecond
+	conf.TimeoutACCEPT = time.Hour
+	conf.TimeoutALLCONFIRM = time.Hour
+
+	nr.SetConf(conf)
+
+	nr.StartStateManager()
+
+	require.Equal(t, common.BallotStateINIT, nr.isaacStateManager.State().BallotState)
+
+	<-recv
+	require.Equal(t, 1, len(b.Messages()))
+
+	<-recv
+	require.Equal(t, common.BallotStateACCEPT, nr.isaacStateManager.State().BallotState)
+	require.Equal(t, 2, len(b.Messages()))
+
+	init, sign, accept := 0, 0, 0
+	for _, message := range b.Messages() {
+		b, ok := message.(block.Ballot)
+		require.True(t, ok)
+		require.Equal(t, 0, len(b.Transactions()))
+		switch b.State() {
+		case common.BallotStateINIT:
+			init++
+			require.Equal(t, common.VotingYES, b.Vote())
+		case common.BallotStateSIGN:
+			sign++
+			require.Equal(t, common.VotingEXP, b.Vote())
+		case common.BallotStateACCEPT:
+			accept++
+			require.Equal(t, common.VotingEXP, b.Vote())
+		}
+	}
+	require.Equal(t, 1, init)
+	require.Equal(t, 0, sign)
+	require.Equal(t, 1, accept)
+}
+
+// 1. All 3 Nodes.
+// 2. Not proposer itself.
+// 3. When `ISAACStateManager` starts, the node waits a ballot by proposer.
+// 4. TimeoutINIT is a millisecond.
+// 5. After milliseconds, the node broadcasts B(`SIGN`, `EXP`).
+// 6. ISAACState is changed to `SIGN`.
+// 7. TimeoutSIGN is a millisecond.
+// 8. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
+func TestStateSIGNTimeoutNotProposer(t *testing.T) {
+	nodeRunners := createTestNodeRunner(3)
+
+	nr := nodeRunners[0]
+
+	recv := make(chan struct{})
+	b := NewTestBroadcaster(recv)
+	nr.SetBroadcaster(b)
+	nr.SetProposerCalculator(TheOtherProposerCalculator{})
+	proposer := nr.CalculateProposer(0, 0)
+
+	require.NotEqual(t, nr.localNode.Address(), proposer)
+
+	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	conf := consensus.NewISAACConfiguration()
+	conf.TimeoutINIT = time.Millisecond
+	conf.TimeoutSIGN = time.Millisecond
+	conf.TimeoutACCEPT = time.Hour
+	conf.TimeoutALLCONFIRM = time.Hour
+
+	nr.SetConf(conf)
+
+	nr.StartStateManager()
+
+	<-recv
+	require.Equal(t, 1, len(b.Messages()))
+
+	<-recv
+	require.Equal(t, 2, len(b.Messages()))
+
+	init, sign, accept := 0, 0, 0
+	for _, message := range b.Messages() {
+		b, ok := message.(block.Ballot)
+		require.True(t, ok)
+		require.Equal(t, 0, len(b.Transactions()))
+		switch b.State() {
+		case common.BallotStateINIT:
+			init++
+			require.Equal(t, common.VotingYES, b.Vote())
+		case common.BallotStateSIGN:
+			sign++
+			require.Equal(t, common.VotingEXP, b.Vote())
+		case common.BallotStateACCEPT:
+			accept++
+			require.Equal(t, common.VotingEXP, b.Vote())
+		}
+	}
+	require.Equal(t, 0, init)
+	require.Equal(t, 1, sign)
+	require.Equal(t, 1, accept)
+}
+
+// 1. All 3 Nodes.
+// 2. Proposer itself at round 0.
+// 3. When `ISAACStateManager` starts, the node proposes a ballot.
+// 4. ISAACState is changed to `SIGN`.
+// 5. TimeoutSIGN is a millisecond.
+// 6. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
+func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
+	nodeRunners := createTestNodeRunner(3)
+
+	nr := nodeRunners[0]
+
+	recv := make(chan struct{})
+	b := NewTestBroadcaster(recv)
+	nr.SetBroadcaster(b)
+	nr.SetProposerCalculator(&SelfProposerThenNotProposer{})
+
+	proposer := nr.CalculateProposer(0, 0)
+	require.Equal(t, nr.localNode.Address(), proposer)
+
+	proposer = nr.CalculateProposer(0, 1)
+	require.NotEqual(t, nr.localNode.Address(), proposer)
+
+	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	conf := consensus.NewISAACConfiguration()
+	conf.TimeoutINIT = time.Hour
+	conf.TimeoutSIGN = time.Millisecond
+	conf.TimeoutACCEPT = time.Millisecond
+	conf.TimeoutALLCONFIRM = time.Hour
+
+	nr.SetConf(conf)
+
+	nr.StartStateManager()
+
+	<-recv
+	require.Equal(t, 1, len(b.Messages()))
+
+	<-recv
+	require.Equal(t, 2, len(b.Messages()))
+	init, sign, accept := 0, 0, 0
+	for _, message := range b.Messages() {
+		b, ok := message.(block.Ballot)
+		require.True(t, ok)
+		require.Equal(t, 0, len(b.Transactions()))
+		switch b.State() {
+		case common.BallotStateINIT:
+			init++
+			require.Equal(t, b.Vote(), common.VotingYES)
+		case common.BallotStateSIGN:
+			sign++
+		case common.BallotStateACCEPT:
+			accept++
+			require.Equal(t, b.Vote(), common.VotingEXP)
+		}
+	}
+
+	require.Equal(t, 1, init)
+	require.Equal(t, 0, sign)
+	require.Equal(t, 1, accept)
+}
+
+// 1. All 3 Nodes.
+// 2. Not proposer itself.
+// 3. When `ISAACStateManager` starts, the node waits for a proposed ballot.
+// 4. TransitISAACState(SIGN) method is called.
+// 5. ISAACState is changed to `SIGN`.
+// 6. TimeoutSIGN is a millisecond.
+// 7. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
+func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
+	nodeRunners := createTestNodeRunner(3)
+	nr := nodeRunners[0]
+
+	recvTransit := make(chan struct{})
+	nr.isaacStateManager.SetTransitSignal(func() {
+		recvTransit <- struct{}{}
+	})
+
+	recvBroadcast := make(chan struct{})
+	b := NewTestBroadcaster(recvBroadcast)
+	nr.SetBroadcaster(b)
+	nr.SetProposerCalculator(TheOtherProposerCalculator{})
+
+	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	conf := consensus.NewISAACConfiguration()
+	conf.TimeoutINIT = time.Hour
+	conf.TimeoutSIGN = time.Millisecond
+	conf.TimeoutACCEPT = time.Millisecond
+	conf.TimeoutALLCONFIRM = time.Millisecond
+
+	nr.SetConf(conf)
+
+	nr.StartStateManager()
+	<-recvTransit
+	require.Equal(t, common.BallotStateINIT, nr.isaacStateManager.State().BallotState)
+
+	nr.TransitISAACState(nr.isaacStateManager.State().Round, common.BallotStateSIGN)
+	<-recvTransit
+	require.Equal(t, common.BallotStateSIGN, nr.isaacStateManager.State().BallotState)
+
+	<-recvBroadcast
+	require.Equal(t, 1, len(b.Messages()))
+
+	for _, message := range b.Messages() {
+		b, ok := message.(block.Ballot)
+		require.True(t, ok)
+		require.Equal(t, nr.localNode.Address(), b.Proposer())
+		require.Equal(t, common.BallotStateACCEPT, b.State())
+		require.Equal(t, common.VotingEXP, b.Vote())
+	}
+}
+
+// 1. All 3 Nodes.
+// 1. Proposer itself.
+// 1. When `ISAACStateManager` starts, the node proposes a ballot.
+// 1. ISAACState is changed to `SIGN`.
+// 1. TransitISAACState(ACCEPT) method is called.
+// 1. ISAACState is changed to `ACCEPT`.
+// 1. TimeoutACCEPT is a millisecond.
+// 1. After timeout, ISAACState is back to `INIT`
+func TestStateTransitFromTimeoutSignToAccept(t *testing.T) {
+	nodeRunners := createTestNodeRunner(3)
+	nr := nodeRunners[0]
+
+	recv := make(chan struct{})
+	b := NewTestBroadcaster(recv)
+	nr.SetBroadcaster(b)
+	nr.SetProposerCalculator(SelfProposerCalculator{})
+
+	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	conf := consensus.NewISAACConfiguration()
+	conf.TimeoutINIT = time.Hour
+	conf.TimeoutSIGN = time.Hour
+	conf.TimeoutACCEPT = time.Millisecond
+	conf.TimeoutALLCONFIRM = time.Millisecond
+
+	nr.SetConf(conf)
+
+	nr.StartStateManager()
+	<-recv
+
+	require.Equal(t, 1, len(b.Messages()))
+	for _, message := range b.Messages() {
+		b, ok := message.(block.Ballot)
+		require.True(t, ok)
+		require.Equal(t, nr.localNode.Address(), b.Proposer())
+		require.Equal(t, common.BallotStateINIT, b.State())
+		require.Equal(t, common.VotingYES, b.Vote())
+	}
+
+	nr.TransitISAACState(nr.isaacStateManager.State().Round, common.BallotStateACCEPT)
+	<-recv
+
+	require.Equal(t, 2, len(b.Messages()))
+	for _, message := range b.Messages() {
+		b, ok := message.(block.Ballot)
+		require.True(t, ok)
+		require.Equal(t, nr.localNode.Address(), b.Proposer())
+		require.Equal(t, common.BallotStateINIT, b.State())
+		require.Equal(t, common.VotingYES, b.Vote())
+	}
+}

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -46,7 +46,8 @@ var DefaultHandleINITBallotCheckerFuncs = []common.CheckerFunc{
 	BallotVote,
 	BallotIsSameProposer,
 	INITBallotValidateTransactions,
-	INITBallotBroadcast,
+	SIGNBallotBroadcast,
+	TransitStateToSIGN,
 }
 
 var DefaultHandleSIGNBallotCheckerFuncs = []common.CheckerFunc{
@@ -54,7 +55,8 @@ var DefaultHandleSIGNBallotCheckerFuncs = []common.CheckerFunc{
 	BallotVote,
 	BallotIsSameProposer,
 	BallotCheckResult,
-	SIGNBallotBroadcast,
+	ACCEPTBallotBroadcast,
+	TransitStateToACCEPT,
 }
 
 var DefaultHandleACCEPTBallotCheckerFuncs = []common.CheckerFunc{
@@ -62,7 +64,7 @@ var DefaultHandleACCEPTBallotCheckerFuncs = []common.CheckerFunc{
 	BallotVote,
 	BallotIsSameProposer,
 	BallotCheckResult,
-	ACCEPTBallotStore,
+	FinishedBallotStore,
 }
 
 type ProposerCalculator interface {
@@ -78,6 +80,7 @@ type NodeRunner struct {
 	connectionManager  *network.ConnectionManager
 	storage            *storage.LevelDBBackend
 	proposerCalculator ProposerCalculator
+	isaacStateManager  *ISAACStateManager
 
 	handleTransactionCheckerFuncs  []common.CheckerFunc
 	handleBaseBallotCheckerFuncs   []common.CheckerFunc
@@ -89,8 +92,6 @@ type NodeRunner struct {
 	handleBallotCheckerDeferFunc      common.CheckerDeferFunc
 
 	log logging.Logger
-
-	timerExpireRound *time.Timer
 }
 
 func NewNodeRunner(
@@ -110,6 +111,7 @@ func NewNodeRunner(
 		storage:   storage,
 		log:       log.New(logging.Ctx{"node": localNode.Alias()}),
 	}
+	nr.isaacStateManager = NewISAACStateManager(nr)
 
 	nr.SetProposerCalculator(SimpleProposerCalculator{})
 	nr.policy.SetValidators(len(nr.localNode.GetValidators()) + 1) // including self
@@ -120,6 +122,8 @@ func NewNodeRunner(
 		nr.policy,
 		nr.localNode.GetValidators(),
 	)
+
+	nr.connectionManager.SetBroadcaster(network.NewSimpleBroadcaster(nr.ConnectionManager()))
 	nr.network.AddWatcher(nr.connectionManager.ConnectionWatcher)
 
 	nr.SetHandleTransactionCheckerFuncs(nil, DefaultHandleTransactionCheckerFuncs...)
@@ -146,6 +150,11 @@ func (nr *NodeRunner) SetProposerCalculator(c ProposerCalculator) {
 }
 
 func (nr *NodeRunner) SetConf(conf *consensus.ISAACConfiguration) {
+	nr.isaacStateManager.SetConf(conf)
+}
+
+func (nr *NodeRunner) SetBroadcaster(b network.Broadcaster) {
+	nr.connectionManager.SetBroadcaster(b)
 }
 
 func (nr *NodeRunner) Ready() {
@@ -212,6 +221,7 @@ func (nr *NodeRunner) Start() (err error) {
 
 func (nr *NodeRunner) Stop() {
 	nr.network.Stop()
+	nr.isaacStateManager.Stop()
 }
 
 func (nr *NodeRunner) Node() *node.LocalNode {
@@ -446,70 +456,26 @@ func (nr *NodeRunner) InitRound() {
 		"validators", nr.Policy().Validators(),
 	)
 
-	go nr.startRound()
+	nr.StartStateManager()
 }
 
-func (nr *NodeRunner) startRound() {
+func (nr *NodeRunner) StartStateManager() {
 	// check whether current running rounds exist
 	if len(nr.consensus.RunningRounds) > 0 {
 		return
 	}
 
-	nr.StartNewRound(0)
+	nr.isaacStateManager.Start()
+	nr.isaacStateManager.NextHeight()
+	return
 }
 
 func (nr *NodeRunner) CalculateProposer(blockHeight uint64, roundNumber uint64) string {
 	return nr.proposerCalculator.Calculate(nr, blockHeight, roundNumber)
 }
 
-func (nr *NodeRunner) StartNewRound(roundNumber uint64) {
-	if nr.timerExpireRound != nil {
-		if !nr.timerExpireRound.Stop() {
-			<-nr.timerExpireRound.C
-		}
-	}
-
-	// wait for new ballot from new proposer
-	nr.timerExpireRound = time.AfterFunc(TimeoutExpireRound,
-		func() {
-			nr.StartNewRound(roundNumber + 1)
-		})
-
-	proposer := nr.CalculateProposer(
-		nr.consensus.LatestConfirmedBlock.Height,
-		roundNumber,
-	)
-
-	log.Debug("calculated proposer", "proposer", proposer)
-
-	if proposer != nr.localNode.Address() {
-		return
-	}
-
-	nr.readyToProposeNewBallot(roundNumber)
-
-	return
-}
-
-func (nr *NodeRunner) readyToProposeNewBallot(roundNumber uint64) {
-	var timeout time.Duration
-	// if incoming transaactions are over `MaxTransactionsInBallot`, just
-	// start.
-	if nr.consensus.TransactionPool.Len() > common.MaxTransactionsInBallot {
-		timeout = TimeoutProposeNewBallotFull
-	} else {
-		timeout = TimeoutProposeNewBallot
-	}
-
-	time.AfterFunc(timeout,
-		func() {
-			if err := nr.proposeNewBallot(roundNumber); err != nil {
-				nr.log.Error("failed to proposeNewBallot", "round", roundNumber, "error", err)
-				nr.StartNewRound(roundNumber)
-			}
-		})
-
-	return
+func (nr *NodeRunner) TransitISAACState(round round.Round, ballotState common.BallotState) {
+	nr.isaacStateManager.TransitISAACState(round, ballotState)
 }
 
 func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
@@ -521,7 +487,7 @@ func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
 	}
 
 	// collect incoming transactions from `TransactionPool`
-	availableTransactions := nr.consensus.TransactionPool.AvailableTransactions(common.MaxTransactionsInBallot)
+	availableTransactions := nr.consensus.TransactionPool.AvailableTransactions(int(nr.isaacStateManager.Conf.TransactionsLimit))
 	nr.log.Debug("new round proposed", "round", round, "transactions", availableTransactions)
 
 	transactionsChecker := &BallotTransactionChecker{
@@ -549,7 +515,7 @@ func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
 
 	nr.log.Debug("new ballot created", "ballot", ballot)
 
-	nr.ConnectionManager().Broadcast(ballot)
+	nr.ConnectionManager().Broadcast(*ballot)
 
 	runningRound, err := consensus.NewRunningRound(nr.localNode.Address(), *ballot)
 	if err != nil {
@@ -561,14 +527,4 @@ func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
 	nr.log.Debug("ballot broadcasted and voted", "runningRound", runningRound)
 
 	return nil
-}
-
-func (nr *NodeRunner) CloseConsensus(ballot block.Ballot, confirmed bool) {
-	nr.consensus.SetLatestRound(ballot.Round())
-
-	if confirmed {
-		go nr.StartNewRound(0)
-	} else {
-		go nr.StartNewRound(ballot.Round().Number + 1)
-	}
 }

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -59,7 +59,7 @@ func createTestNodeRunner(n int) []*NodeRunner {
 	for i := 0; i < n; i++ {
 		v := nodes[i]
 		p, _ := consensus.NewDefaultVotingThresholdPolicy(66, 66)
-		is, _ := consensus.NewISAAC(networkID, v, p)
+		is, _ := consensus.NewISAAC(networkID, v, p, ns[i])
 		st, _ := storage.NewTestMemoryLevelDBBackend()
 
 		account.Save(st)
@@ -151,10 +151,10 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 	)
 	for _, node := range nodes {
 		vth, _ := consensus.NewDefaultVotingThresholdPolicy(66, 66)
-		is, _ := consensus.NewISAAC(networkID, node, vth)
 		st, _ := storage.NewTestMemoryLevelDBBackend()
 		networkConfig, _ := network.NewHTTP2NetworkConfigFromEndpoint(node.Alias(), node.Endpoint())
 		network := network.NewHTTP2Network(networkConfig)
+		is, _ := consensus.NewISAAC(networkID, node, vth, network)
 		nodeRunner, _ := NewNodeRunner(string(networkID), node, vth, network, is, st)
 
 		genesisAccount.Save(nodeRunner.Storage())

--- a/lib/node/runner/proposer_calculator_test.go
+++ b/lib/node/runner/proposer_calculator_test.go
@@ -11,11 +11,13 @@ func TestProposerCalculator(t *testing.T) {
 	nodeRunners := createTestNodeRunner(1)
 
 	nodeRunner := nodeRunners[0]
-	nodeRunner.SetProposerCalculator(SelfProposerCalculator{})
+	nodeRunner.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nodeRunner,
+	})
 
-	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(1, 0))
-	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(2, 0))
-	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(2, 1))
+	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.Consensus().CalculateProposer(1, 0))
+	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.Consensus().CalculateProposer(2, 0))
+	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.Consensus().CalculateProposer(2, 1))
 }
 
 // All 3 nodes have the same proposer at each round
@@ -37,9 +39,9 @@ func TestNodesHaveSameProposers(t *testing.T) {
 
 	for i := uint64(0); i < maximumBlockHeight; i++ {
 		for j := uint64(0); j < maximumRoundNumber; j++ {
-			proposers0[i*maximumRoundNumber] = nr0.CalculateProposer(i, j)
-			proposers1[i*maximumRoundNumber] = nr1.CalculateProposer(i, j)
-			proposers2[i*maximumRoundNumber] = nr2.CalculateProposer(i, j)
+			proposers0[i*maximumRoundNumber] = nr0.Consensus().CalculateProposer(i, j)
+			proposers1[i*maximumRoundNumber] = nr1.Consensus().CalculateProposer(i, j)
+			proposers2[i*maximumRoundNumber] = nr2.Consensus().CalculateProposer(i, j)
 		}
 	}
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -43,7 +43,7 @@ for dir in ${TEST_DIRS}; do
     DOCKER_CONTAINERS="${DOCKER_CONTAINERS} ${NODE1} ${NODE2} ${NODE3}"
 
     # Give them a bit of time
-    sleep 3
+    sleep 10
 
     # Run the tests
     docker run --rm --network host ${TESTS_DOCKER_IMAGE} ${dir}

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -33,7 +33,7 @@ function getAccountWithBalance () # u16 port, string addr and expected balance
 	    if [ "$balance" == "$3" ];then
 		    return 0
 	    fi
-	    sleep 0.3
+	    sleep 1
     done
 
     echo $balance


### PR DESCRIPTION
### Background
<!--
    Explain why this pull request was created.
-->
The branch [`impl-new-isaac`](https://github.com/bosnet/sebak/pull/358) has data race in `RunningRounds` so I should modify to pass.
In this implementing process, refactoring is needed because ISAAC should have `ProposerCalculator`.
Without it, [This](https://github.com/Charleslee522/sebak/compare/impl-new-isaac...Charleslee522:data-race-running-round?expand=1#diff-7f79ac520823e445bff5cd70f53bcf59L138) codes cannot be moved into `ISAAC`.

### Solution
<!-- 
    Explain how you solved this problem.
-->
1. Refactoring
   * ISAAC also has connectionManager
   * ISAAC has ProposerCalculator
1. Data race
   * Use RWLock in ISAAC and RLock and RUnlock in method which is include RunningRounds.
   * All `RunningRounds` related logic is in ISAAC, not in Checker.
   * Use RWLock in LatestConfirmedBlock method.

ps. I wanted to and tried to breakdown but it's not easy because all changes are related.